### PR TITLE
Enforce read-only references

### DIFF
--- a/dist/morphlex.js
+++ b/dist/morphlex.js
@@ -1,10 +1,11 @@
 export function morph(node, reference) {
-	const idMap = new Map();
-	if (isParentNode(node) && isParentNode(reference)) {
+	const readonlyReference = reference;
+	const idMap = new WeakMap();
+	if (isParentNode(node) && isParentNode(readonlyReference)) {
 		populateIdSets(node, idMap);
-		populateIdSets(reference, idMap);
+		populateIdSets(readonlyReference, idMap);
 	}
-	morphNodes(node, reference, idMap);
+	morphNodes(node, readonlyReference, idMap);
 }
 // For each node with an ID, push that ID into the IdSet on the IdMap, for each of its parent elements.
 function populateIdSets(node, idMap) {
@@ -109,9 +110,6 @@ function morphChildElement(child, ref, parent, idMap) {
 		morphNodes(nextMatchByTagName, ref, idMap);
 	} else child.replaceWith(ref.cloneNode(true));
 }
-// We cannot use `instanceof` when nodes might be from different documents,
-// so we use type guards instead. This keeps TypeScript happy, while doing
-// the necessary checks at runtime.
 function isText(node) {
 	return node.nodeType === 3;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,24 @@
 {
 	"name": "morphlex",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "morphlex",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@open-wc/testing": "^3.0.0-next.5",
 				"@web/test-runner": "^0.18.0",
-				"eslint": "^8.57.0",
 				"prettier": "^3.2.5",
 				"terser": "^5.28.1",
 				"typescript": "^5.3.3",
 				"typescript-eslint": "^7.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/joeldrapper"
 			}
 		},
 		"node_modules/@75lb/deep-merge": {
@@ -45,6 +48,7 @@
 			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -114,6 +118,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
 			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -137,6 +142,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
 			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -155,6 +161,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
 			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.2",
 				"debug": "^4.3.1",
@@ -169,6 +176,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -181,7 +189,8 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
 			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.4",
@@ -1265,7 +1274,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@web/browser-logs": {
 			"version": "0.4.0",
@@ -1531,6 +1541,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -1552,6 +1563,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1616,7 +1628,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/array-back": {
 			"version": "3.1.0",
@@ -1746,6 +1759,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1860,6 +1874,7 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2230,7 +2245,8 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -2286,6 +2302,7 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2337,7 +2354,8 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
@@ -2454,6 +2472,7 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -2584,6 +2603,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
 			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -2639,6 +2659,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -2667,6 +2688,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -2682,6 +2704,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -2698,6 +2721,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -2709,13 +2733,15 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2728,6 +2754,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -2740,6 +2767,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2749,6 +2777,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -2761,6 +2790,7 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -2791,6 +2821,7 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -2803,6 +2834,7 @@
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -2882,7 +2914,8 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-fifo": {
 			"version": "1.3.2",
@@ -2910,13 +2943,15 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
@@ -2941,6 +2976,7 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -2977,6 +3013,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -2993,6 +3030,7 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -3006,7 +3044,8 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fresh": {
 			"version": "0.5.2",
@@ -3035,7 +3074,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -3120,6 +3160,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -3152,6 +3193,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
 			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -3167,6 +3209,7 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3406,6 +3449,7 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -3422,6 +3466,7 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -3440,6 +3485,7 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -3589,6 +3635,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3633,7 +3680,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -3703,6 +3751,7 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -3720,19 +3769,22 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
@@ -3763,6 +3815,7 @@
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -3870,6 +3923,7 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -3939,6 +3993,7 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -3971,7 +4026,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/log-update": {
 			"version": "4.0.0",
@@ -4087,6 +4143,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -4305,6 +4362,7 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
 			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
@@ -4322,6 +4380,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -4337,6 +4396,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -4384,6 +4444,7 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -4411,6 +4472,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4429,6 +4491,7 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4506,6 +4569,7 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -4757,6 +4821,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -4838,6 +4903,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -4984,6 +5050,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -4996,6 +5063,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5217,6 +5285,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -5331,7 +5400,8 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
@@ -5404,6 +5474,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -5522,6 +5593,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -5576,6 +5648,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -5735,6 +5808,7 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"build": "tsc && prettier --write ./src ./dist",
 		"watch": "tsc -w",
 		"test:watch": "npm run test -- --watch",
-		"lint": "prettier --check ./src ./dist && eslint ./src",
+		"lint": "prettier --check ./src ./dist",
 		"minify": "terser dist/morphlex.js -o dist/morphlex.min.js -c -m --module",
 		"prepare": "npm run build && npm run minify",
 		"ship": "npm run prepare && npm run test && npm run lint && npm publish"
@@ -24,7 +24,6 @@
 	"devDependencies": {
 		"@open-wc/testing": "^3.0.0-next.5",
 		"@web/test-runner": "^0.18.0",
-		"eslint": "^8.57.0",
 		"prettier": "^3.2.5",
 		"terser": "^5.28.1",
 		"typescript": "^5.3.3",

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -11,19 +11,21 @@ interface ReadOnlyNodeInterface<T extends Node> {
 	readonly cloneNode: (deep: true) => Node;
 
 	// These return read-only node lists to maintain the read-only-ness of associated nodes.
-	readonly childNodes: NodeListOf<ChildNode> | ReadOnlyNodeList<ChildNode>;
-	readonly querySelectorAll: (query: string) => NodeListOf<Element> | ReadOnlyNodeList<Element>;
+	readonly childNodes: ReadOnlyNodeList<ChildNode>;
+	readonly querySelectorAll: (query: string) => ReadOnlyNodeList<Element>;
 
 	// This returns a read-only node, so that the node can’t be mutated.
-	readonly parentElement: ReadOnlyNodeInterface<T> | Element | null;
+	readonly parentElement: ReadOnlyNode<Element> | null;
+
+	// Other functions
+	readonly hasAttribute: (name: string) => boolean;
+	readonly hasAttributes: () => boolean;
+	readonly hasChildNodes: () => boolean;
 
 	// Other properties
 	readonly attributes: NamedNodeMap;
 	readonly checked: boolean;
 	readonly disabled: boolean;
-	readonly hasAttribute: (name: string) => boolean;
-	readonly hasAttributes: () => boolean;
-	readonly hasChildNodes: () => boolean;
 	readonly id: string;
 	readonly indeterminate: boolean;
 	readonly localName: string;
@@ -37,15 +39,16 @@ interface ReadOnlyNodeInterface<T extends Node> {
 
 // This interface for a read-only node list works to maintain the read-only-ness of
 // associated nodes. See ReadOnlyNodeInterface[childNodes] for example.
-interface ReadOnlyNodeList<T extends Node> {
-	[Symbol.iterator](): IterableIterator<T | ReadOnlyNodeInterface<T>>;
-	readonly [index: number]: T | ReadOnlyNodeInterface<T>;
+interface ReadOnlyNodeListInterface<T extends Node> {
+	[Symbol.iterator](): IterableIterator<ReadOnlyNode<T>>;
+	readonly [index: number]: ReadOnlyNode<T>;
 	readonly length: NodeListOf<T>["length"];
 }
 
 // This generic type sets up the intersection between the specific Node type
 // and the read-only interface.
 type ReadOnlyNode<T extends Node> = T | ReadOnlyNodeInterface<T>;
+type ReadOnlyNodeList<T extends Node> = NodeListOf<T> | ReadOnlyNodeListInterface<T>;
 
 export function morph(node: ChildNode, reference: ChildNode): void {
 	const readonlyReference = reference as ReadOnlyNode<ChildNode>;

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -6,6 +6,7 @@ type StrongReadOnly<T> = {
 	readonly [K in keyof T as T[K] extends Function ? never : K]: T[K];
 };
 
+// Maps a Node to a type limited to read-only properties and methods for that Node
 type ReadOnlyNode<T extends Node> =
 	| T
 	| (StrongReadOnly<T> & {
@@ -18,6 +19,7 @@ type ReadOnlyNode<T extends Node> =
 			readonly hasChildNodes: () => boolean;
 	  });
 
+// Maps a node to a read-only node list of nodes of that type
 type ReadOnlyNodeList<T extends Node> =
 	| NodeListOf<T>
 	| {

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -1,38 +1,22 @@
 type IdSet = Set<string>;
 type IdMap = WeakMap<ReadOnlyNode<Node>, IdSet>;
 
+// Maps to a type that can only read properties
+type StrongReadOnly<T> = {
+	readonly [K in keyof T as T[K] extends Function ? never : K]: T[K];
+};
+
 type ReadOnlyNode<T extends Node> =
 	| T
-	| {
-			// Here, `deep` must be `true` and the return type is not read-only because it’s a new node.
+	| (StrongReadOnly<T> & {
 			readonly cloneNode: (deep: true) => Node;
-
-			// These return read-only node lists to maintain the read-only-ness of associated nodes.
 			readonly childNodes: ReadOnlyNodeList<ChildNode>;
 			readonly querySelectorAll: (query: string) => ReadOnlyNodeList<Element>;
-
-			// This returns a read-only node, so that the node can’t be mutated.
 			readonly parentElement: ReadOnlyNode<Element> | null;
-
-			// Other non-mutating functions
 			readonly hasAttribute: (name: string) => boolean;
 			readonly hasAttributes: () => boolean;
 			readonly hasChildNodes: () => boolean;
-
-			// Other properties
-			readonly attributes: NamedNodeMap;
-			readonly checked: boolean;
-			readonly disabled: boolean;
-			readonly id: string;
-			readonly indeterminate: boolean;
-			readonly localName: string;
-			readonly nodeType: number;
-			readonly nodeValue: string | null;
-			readonly selected: boolean;
-			readonly tagName: string;
-			readonly textContent: string;
-			readonly value: string;
-	  };
+	  });
 
 type ReadOnlyNodeList<T extends Node> =
 	| NodeListOf<T>

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -7,25 +7,32 @@ type IdMap = WeakMap<ReadOnlyNode<Node>, IdSet>;
 // thing is it doesn’t include any setters or methods that could mutate
 // the node.
 interface ReadOnlyNodeInterface<T extends Node> {
-	readonly attributes: Element["attributes"];
-	readonly checked: HTMLInputElement["checked"];
-	readonly childNodes: ParentNode["childNodes"] | ReadOnlyNodeList<ChildNode>;
-	readonly cloneNode: Node["cloneNode"];
-	readonly disabled: HTMLInputElement["disabled"];
-	readonly hasAttribute: Element["hasAttribute"];
-	readonly hasAttributes: Element["hasAttributes"];
-	readonly hasChildNodes: ParentNode["hasChildNodes"];
-	readonly id: Element["id"];
-	readonly indeterminate: HTMLInputElement["indeterminate"];
-	readonly localName: Element["localName"];
-	readonly nodeType: Node["nodeType"];
-	readonly nodeValue: Node["nodeValue"];
-	readonly parentElement: ReadOnlyNodeInterface<T> | Element["parentElement"];
+	// Here, `deep` must be `true` and the return type is not read-only because it’s a new node.
+	readonly cloneNode: (deep: true) => Node;
+
+	// These return read-only node lists to maintain the read-only-ness of associated nodes.
+	readonly childNodes: NodeListOf<ChildNode> | ReadOnlyNodeList<ChildNode>;
 	readonly querySelectorAll: (query: string) => NodeListOf<Element> | ReadOnlyNodeList<Element>;
-	readonly selected: HTMLOptionElement["selected"];
-	readonly tagName: Element["tagName"];
-	readonly textContent: Node["textContent"];
-	readonly value: HTMLInputElement["value"];
+
+	// This returns a read-only node, so that the node can’t be mutated.
+	readonly parentElement: ReadOnlyNodeInterface<T> | Element | null;
+
+	// Other properties
+	readonly attributes: NamedNodeMap;
+	readonly checked: boolean;
+	readonly disabled: boolean;
+	readonly hasAttribute: (name: string) => boolean;
+	readonly hasAttributes: () => boolean;
+	readonly hasChildNodes: () => boolean;
+	readonly id: string;
+	readonly indeterminate: boolean;
+	readonly localName: string;
+	readonly nodeType: number;
+	readonly nodeValue: string | null;
+	readonly selected: boolean;
+	readonly tagName: string;
+	readonly textContent: string;
+	readonly value: string;
 }
 
 // This interface for a read-only node list works to maintain the read-only-ness of

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -1,20 +1,60 @@
 type IdSet = Set<string>;
-type IdMap = Map<Node, IdSet>;
+type IdMap = WeakMap<ReadOnlyNode<Node>, IdSet>;
+
+// This maps out the read-only interface that we use on reference nodes.
+// Because this is used with an intersection type, it doesn’t matter that
+// it includes properties that aren’t on all types of node. The important
+// thing is it doesn’t include any setters or methods that could mutate
+// the node.
+interface ReadOnlyNodeInterface<T extends Node> {
+	readonly attributes: Element["attributes"];
+	readonly checked: HTMLInputElement["checked"];
+	readonly childNodes: ParentNode["childNodes"] | ReadOnlyNodeList<ChildNode>;
+	readonly cloneNode: Node["cloneNode"];
+	readonly disabled: HTMLInputElement["disabled"];
+	readonly hasAttribute: Element["hasAttribute"];
+	readonly hasAttributes: Element["hasAttributes"];
+	readonly hasChildNodes: ParentNode["hasChildNodes"];
+	readonly id: Element["id"];
+	readonly indeterminate: HTMLInputElement["indeterminate"];
+	readonly localName: Element["localName"];
+	readonly nodeType: Node["nodeType"];
+	readonly nodeValue: Node["nodeValue"];
+	readonly parentElement: ReadOnlyNodeInterface<T> | Element["parentElement"];
+	readonly querySelectorAll: (query: string) => NodeListOf<Element> | ReadOnlyNodeList<Element>;
+	readonly selected: HTMLOptionElement["selected"];
+	readonly tagName: Element["tagName"];
+	readonly textContent: Node["textContent"];
+	readonly value: HTMLInputElement["value"];
+}
+
+// This interface for a read-only node list works to maintain the read-only-ness of
+// associated nodes. See ReadOnlyNodeInterface[childNodes] for example.
+interface ReadOnlyNodeList<T extends Node> {
+	[Symbol.iterator](): IterableIterator<T | ReadOnlyNodeInterface<T>>;
+	readonly [index: number]: T | ReadOnlyNodeInterface<T>;
+	readonly length: NodeListOf<T>["length"];
+}
+
+// This generic type sets up the intersection between the specific Node type
+// and the read-only interface.
+type ReadOnlyNode<T extends Node> = T | ReadOnlyNodeInterface<T>;
 
 export function morph(node: ChildNode, reference: ChildNode): void {
-	const idMap: IdMap = new Map();
+	const readonlyReference = reference as ReadOnlyNode<ChildNode>;
+	const idMap: IdMap = new WeakMap();
 
-	if (isParentNode(node) && isParentNode(reference)) {
+	if (isParentNode(node) && isParentNode(readonlyReference)) {
 		populateIdSets(node, idMap);
-		populateIdSets(reference, idMap);
+		populateIdSets(readonlyReference, idMap);
 	}
 
-	morphNodes(node, reference, idMap);
+	morphNodes(node, readonlyReference, idMap);
 }
 
 // For each node with an ID, push that ID into the IdSet on the IdMap, for each of its parent elements.
-function populateIdSets(node: ParentNode, idMap: IdMap): void {
-	const elementsWithIds: NodeListOf<Element> = node.querySelectorAll("[id]");
+function populateIdSets(node: ReadOnlyNode<ParentNode>, idMap: IdMap): void {
+	const elementsWithIds = node.querySelectorAll("[id]");
 
 	for (const elementWithId of elementsWithIds) {
 		const id = elementWithId.id;
@@ -22,7 +62,7 @@ function populateIdSets(node: ParentNode, idMap: IdMap): void {
 		// Ignore empty IDs
 		if (id === "") continue;
 
-		let current: Element | null = elementWithId;
+		let current: ReadOnlyNode<Element> | null = elementWithId;
 
 		while (current) {
 			const idSet: IdSet | undefined = idMap.get(current);
@@ -34,17 +74,17 @@ function populateIdSets(node: ParentNode, idMap: IdMap): void {
 }
 
 // This is where we actually morph the nodes. The `morph` function exists to set up the `idMap`.
-function morphNodes(node: ChildNode, ref: ChildNode, idMap: IdMap): void {
+function morphNodes(node: ChildNode, ref: ReadOnlyNode<ChildNode>, idMap: IdMap): void {
 	if (isElement(node) && isElement(ref) && node.tagName === ref.tagName) {
 		// We need to check if the element is an input, option, or textarea here, because they have
 		// special attributes not covered by the isEqualNode check.
-		if (!isInput(node) && !isOption(node) && !isTextArea(node) && node.isEqualNode(ref)) return;
+		if (!isInput(node) && !isOption(node) && !isTextArea(node) && node.isEqualNode(ref as Node)) return;
 		else {
 			if (node.hasAttributes() || ref.hasAttributes()) morphAttributes(node, ref);
 			if (node.hasChildNodes() || ref.hasChildNodes()) morphChildNodes(node, ref, idMap);
 		}
 	} else {
-		if (node.isEqualNode(ref)) return;
+		if (node.isEqualNode(ref as Node)) return;
 		else if (isText(node) && isText(ref)) {
 			if (node.textContent !== ref.textContent) node.textContent = ref.textContent;
 		} else if (isComment(node) && isComment(ref)) {
@@ -53,7 +93,7 @@ function morphNodes(node: ChildNode, ref: ChildNode, idMap: IdMap): void {
 	}
 }
 
-function morphAttributes(elm: Element, ref: Element): void {
+function morphAttributes(elm: Element, ref: ReadOnlyNode<Element>): void {
 	// Remove any excess attributes from the element that aren’t present in the reference.
 	for (const { name } of elm.attributes) ref.hasAttribute(name) || elm.removeAttribute(name);
 
@@ -79,7 +119,7 @@ function morphAttributes(elm: Element, ref: Element): void {
 }
 
 // Iterates over the child nodes of the reference element, morphing the main element’s child nodes to match.
-function morphChildNodes(element: Element, ref: Element, idMap: IdMap): void {
+function morphChildNodes(element: Element, ref: ReadOnlyNode<Element>, idMap: IdMap): void {
 	const childNodes = [...element.childNodes];
 	const refChildNodes = [...ref.childNodes];
 
@@ -97,12 +137,12 @@ function morphChildNodes(element: Element, ref: Element, idMap: IdMap): void {
 	while (element.childNodes.length > ref.childNodes.length) element.lastChild?.remove();
 }
 
-function morphChildNode(child: ChildNode, ref: ChildNode, parent: Element, idMap: IdMap): void {
+function morphChildNode(child: ChildNode, ref: ReadOnlyNode<ChildNode>, parent: Element, idMap: IdMap): void {
 	if (isElement(child) && isElement(ref)) morphChildElement(child, ref, parent, idMap);
 	else morphNodes(child, ref, idMap);
 }
 
-function morphChildElement(child: Element, ref: Element, parent: Element, idMap: IdMap): void {
+function morphChildElement(child: Element, ref: ReadOnlyNode<Element>, parent: Element, idMap: IdMap): void {
 	const refIdSet = idMap.get(ref);
 
 	// Generate the array in advance of the loop
@@ -142,30 +182,44 @@ function morphChildElement(child: Element, ref: Element, parent: Element, idMap:
 // so we use type guards instead. This keeps TypeScript happy, while doing
 // the necessary checks at runtime.
 
-function isText(node: Node): node is Text {
+function isText(node: Node): node is Text;
+function isText(node: ReadOnlyNode<Node>): node is ReadOnlyNode<Text>;
+function isText(node: Node | ReadOnlyNode<Node>): boolean {
 	return node.nodeType === 3;
 }
 
-function isComment(node: Node): node is Comment {
+function isComment(node: Node): node is Comment;
+function isComment(node: ReadOnlyNode<Node>): node is ReadOnlyNode<Comment>;
+function isComment(node: Node | ReadOnlyNode<Node>): boolean {
 	return node.nodeType === 8;
 }
 
-function isElement(node: Node): node is Element {
+function isElement(node: Node): node is Element;
+function isElement(node: ReadOnlyNode<Node>): node is ReadOnlyNode<Element>;
+function isElement(node: Node | ReadOnlyNode<Node>): boolean {
 	return node.nodeType === 1;
 }
 
-function isInput(element: Element): element is HTMLInputElement {
+function isInput(element: Element): element is HTMLInputElement;
+function isInput(element: ReadOnlyNode<Element>): element is ReadOnlyNode<HTMLInputElement>;
+function isInput(element: Element | ReadOnlyNode<Element>): boolean {
 	return element.localName === "input";
 }
 
-function isOption(element: Element): element is HTMLOptionElement {
+function isOption(element: Element): element is HTMLOptionElement;
+function isOption(element: ReadOnlyNode<Element>): element is ReadOnlyNode<HTMLOptionElement>;
+function isOption(element: Element | ReadOnlyNode<Element>): boolean {
 	return element.localName === "option";
 }
 
-function isTextArea(element: Element): element is HTMLTextAreaElement {
+function isTextArea(element: Element): element is HTMLTextAreaElement;
+function isTextArea(element: ReadOnlyNode<Element>): element is ReadOnlyNode<HTMLTextAreaElement>;
+function isTextArea(element: Element | ReadOnlyNode<Element>): boolean {
 	return element.localName === "textarea";
 }
 
-function isParentNode(node: Node): node is ParentNode {
+function isParentNode(node: Node): node is ParentNode;
+function isParentNode(node: ReadOnlyNode<Node>): node is ReadOnlyNode<ParentNode>;
+function isParentNode(node: Node | ReadOnlyNode<Node>): boolean {
 	return node.nodeType === 1 || node.nodeType === 9 || node.nodeType === 11;
 }

--- a/src/morphlex.ts
+++ b/src/morphlex.ts
@@ -1,54 +1,46 @@
 type IdSet = Set<string>;
 type IdMap = WeakMap<ReadOnlyNode<Node>, IdSet>;
 
-// This maps out the read-only interface that we use on reference nodes.
-// Because this is used with an intersection type, it doesn’t matter that
-// it includes properties that aren’t on all types of node. The important
-// thing is it doesn’t include any setters or methods that could mutate
-// the node.
-interface ReadOnlyNodeInterface<T extends Node> {
-	// Here, `deep` must be `true` and the return type is not read-only because it’s a new node.
-	readonly cloneNode: (deep: true) => Node;
+type ReadOnlyNode<T extends Node> =
+	| T
+	| {
+			// Here, `deep` must be `true` and the return type is not read-only because it’s a new node.
+			readonly cloneNode: (deep: true) => Node;
 
-	// These return read-only node lists to maintain the read-only-ness of associated nodes.
-	readonly childNodes: ReadOnlyNodeList<ChildNode>;
-	readonly querySelectorAll: (query: string) => ReadOnlyNodeList<Element>;
+			// These return read-only node lists to maintain the read-only-ness of associated nodes.
+			readonly childNodes: ReadOnlyNodeList<ChildNode>;
+			readonly querySelectorAll: (query: string) => ReadOnlyNodeList<Element>;
 
-	// This returns a read-only node, so that the node can’t be mutated.
-	readonly parentElement: ReadOnlyNode<Element> | null;
+			// This returns a read-only node, so that the node can’t be mutated.
+			readonly parentElement: ReadOnlyNode<Element> | null;
 
-	// Other functions
-	readonly hasAttribute: (name: string) => boolean;
-	readonly hasAttributes: () => boolean;
-	readonly hasChildNodes: () => boolean;
+			// Other non-mutating functions
+			readonly hasAttribute: (name: string) => boolean;
+			readonly hasAttributes: () => boolean;
+			readonly hasChildNodes: () => boolean;
 
-	// Other properties
-	readonly attributes: NamedNodeMap;
-	readonly checked: boolean;
-	readonly disabled: boolean;
-	readonly id: string;
-	readonly indeterminate: boolean;
-	readonly localName: string;
-	readonly nodeType: number;
-	readonly nodeValue: string | null;
-	readonly selected: boolean;
-	readonly tagName: string;
-	readonly textContent: string;
-	readonly value: string;
-}
+			// Other properties
+			readonly attributes: NamedNodeMap;
+			readonly checked: boolean;
+			readonly disabled: boolean;
+			readonly id: string;
+			readonly indeterminate: boolean;
+			readonly localName: string;
+			readonly nodeType: number;
+			readonly nodeValue: string | null;
+			readonly selected: boolean;
+			readonly tagName: string;
+			readonly textContent: string;
+			readonly value: string;
+	  };
 
-// This interface for a read-only node list works to maintain the read-only-ness of
-// associated nodes. See ReadOnlyNodeInterface[childNodes] for example.
-interface ReadOnlyNodeListInterface<T extends Node> {
-	[Symbol.iterator](): IterableIterator<ReadOnlyNode<T>>;
-	readonly [index: number]: ReadOnlyNode<T>;
-	readonly length: NodeListOf<T>["length"];
-}
-
-// This generic type sets up the intersection between the specific Node type
-// and the read-only interface.
-type ReadOnlyNode<T extends Node> = T | ReadOnlyNodeInterface<T>;
-type ReadOnlyNodeList<T extends Node> = NodeListOf<T> | ReadOnlyNodeListInterface<T>;
+type ReadOnlyNodeList<T extends Node> =
+	| NodeListOf<T>
+	| {
+			[Symbol.iterator](): IterableIterator<ReadOnlyNode<T>>;
+			readonly [index: number]: ReadOnlyNode<T>;
+			readonly length: NodeListOf<T>["length"];
+	  };
 
 export function morph(node: ChildNode, reference: ChildNode): void {
 	const readonlyReference = reference as ReadOnlyNode<ChildNode>;


### PR DESCRIPTION
I’m experimenting with using TypeScript to enforce the reference nodes to be read-only. 

This means if a function takes a reference as a readonly node, e.g. `ref: ReadOnlyNode<Element>`, it will be impossible to mutate it — say, by setting `value = "foo"`. This read-only-ness carries over to other nodes and node lists referenced from the read-only-node. The only way to get back to a mutable reference is to make a deep copy.

I’m in two minds about this feature. It doesn’t really impact the output JavaScript at all, and I don’t think it will be difficult to maintain. But it does add a lot of code. 🤔 